### PR TITLE
fixed deprecated code.

### DIFF
--- a/config/Migrations/20161109095904_AttachmentsAdd.php
+++ b/config/Migrations/20161109095904_AttachmentsAdd.php
@@ -77,6 +77,6 @@ class AttachmentsAdd extends AbstractMigration
 
     public function down()
     {
-        $this->dropTable('attachments');
+        $this->table('attachments')->drop()->update();
     }
 }


### PR DESCRIPTION
dropTable() is already deprecated.
The new style is `$this->table($tableName)->drop()->save();`
see: https://github.com/cakephp/phinx/blob/master/src/Phinx/Migration/AbstractMigration.php#L320