### PR TITLE
 ContentsFileControllerに記載されている拡張子以外でもダウンロードできるように修正

### DIFF
--- a/src/Controller/ContentsFileController.php
+++ b/src/Controller/ContentsFileController.php
@@ -174,7 +174,7 @@ class ContentsFileController extends AppController
             // 拡張子がある場合
             $ext = strtolower(substr($filename, $pos + 1));
             if (strlen($ext)) {
-                return $aContentTypes[$ext] ? $aContentTypes[$ext] : $sContentType;
+                return array_key_exists($ext, $aContentTypes) ? $aContentTypes[$ext] : $sContentType;
             }
         }
         return $sContentType;


### PR DESCRIPTION
## 問題
xls, xlsmをダウンロードするとき、$aContentTypes(147行目に定義されている)にxls, xlsmがないため警告が表示される

## 修正
$aContentTypesのキーにxls, xlsmが存在するか判断し、存在しなければ以下を適応してダウンロードできるようにした

```
### 171行目
$sContentType = 'application/octet-stream';
```