### PR TITLE
S3アップロード時にkey, secretを省略可能とした

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Configure::write('ContentsFile.Setting', [
     'ext' => true,
     'S3' => [
         'key' => 'KEY',
-        'secret' => 'SECRET',
-        'bucket' => 'BUCKET_NAME',
+        'secret' => 'SECRET',      // IAM Roleを利用する場合、省略可能
+        'bucket' => 'BUCKET_NAME', // IAM Roleを利用する場合、省略可能
         'tmpDir' => 'tmp',
         'fileDir' => 'file',
         'workingDir' => TMP,

--- a/src/Aws/S3.php
+++ b/src/Aws/S3.php
@@ -26,8 +26,6 @@ class S3
         $S3Setting = Configure::read('ContentsFile.Setting.S3');
         if (
             !is_array($S3Setting) ||
-            !array_key_exists('key', $S3Setting) ||
-            !array_key_exists('secret', $S3Setting) ||
             !array_key_exists('bucket', $S3Setting) ||
             !array_key_exists('tmpDir', $S3Setting) ||
             !array_key_exists('fileDir', $S3Setting)
@@ -35,16 +33,20 @@ class S3
             throw new InternalErrorException('contentsFileS3Config paramater shortage');
         }
         // S3に接続するためのクライアントを用意します。
-        $key    = Configure::read('ContentsFile.Setting.S3.key');
-        $secret = Configure::read('ContentsFile.Setting.S3.secret');
-        $sdk = new Sdk([
-            'credentials' => array(
-                'key'=> $key,
-                'secret' => $secret,
-            ),
+        $config = array(
             'version' => 'latest',
             'region'  => 'ap-northeast-1'
-        ]);
+        );
+        // key, secretが指定されている場合はcredentialsを設定する
+        $key    = Configure::read('ContentsFile.Setting.S3.key');
+        $secret = Configure::read('ContentsFile.Setting.S3.secret');
+        if (!empty($key) && !empty($secret)) {
+            $config['credentials'] = array(
+                'key'=> $key,
+                'secret' => $secret,
+            );
+        }
+        $sdk = new Sdk($config);
         $this->client = $sdk->createS3();
     }
 

--- a/src/Model/Behavior/Traits/S3ContentsFileBehaviorTrait.php
+++ b/src/Model/Behavior/Traits/S3ContentsFileBehaviorTrait.php
@@ -29,8 +29,6 @@ trait S3ContentsFileBehaviorTrait
         $s3Setting = Configure::read('ContentsFile.Setting.S3');
         if (
             !is_array($s3Setting) ||
-            !array_key_exists('key', $s3Setting) ||
-            !array_key_exists('secret', $s3Setting) ||
             !array_key_exists('bucket', $s3Setting) ||
             !array_key_exists('tmpDir', $s3Setting) ||
             !array_key_exists('fileDir', $s3Setting) ||


### PR DESCRIPTION
EC2に対してIAM Roleを割り当てる場合、key, secretを設定する必要がないため
省略可能としました。