### PR TITLE
ファイル名が「文字列+空白+日本語文字列」だったら、「文字列」になる問題を直す

### DIFF
--- a/src/Controller/ContentsFileController.php
+++ b/src/Controller/ContentsFileController.php
@@ -189,6 +189,8 @@ class ContentsFileController extends AppController
     {
         // loaderよりダウンロードするかどうか
         if (!empty($this->request->getQuery('download')) && $this->request->getQuery('download') == true) {
+            $this->response->header('Content-Disposition', 'attachment;filename="' . rawurlencode($filename) . '"');
+
             // IE/Edge対応
             if (strstr(env('HTTP_USER_AGENT'), 'MSIE') || strstr(env('HTTP_USER_AGENT'), 'Trident') || strstr(env('HTTP_USER_AGENT'), 'Edge')) {
                 $filename = mb_convert_encoding($filename, "SJIS", "UTF-8");

--- a/src/Controller/ContentsFileController.php
+++ b/src/Controller/ContentsFileController.php
@@ -189,7 +189,7 @@ class ContentsFileController extends AppController
     {
         $filename = rawurlencode($filename);
         // loaderよりダウンロードするかどうか
-        if (!empty($this->request->query['download']) && $this->request->query['download'] == true) {
+        if (!empty($this->request->getQuery('download')) && $this->request->getQuery('download') == true) {
             // IE/Edge対応
             if (strstr(env('HTTP_USER_AGENT'), 'MSIE') || strstr(env('HTTP_USER_AGENT'), 'Trident') || strstr(env('HTTP_USER_AGENT'), 'Edge')) {
                 $filename = mb_convert_encoding($filename, "SJIS", "UTF-8");

--- a/src/Controller/ContentsFileController.php
+++ b/src/Controller/ContentsFileController.php
@@ -187,15 +187,14 @@ class ContentsFileController extends AppController
      */
     private function fileDownloadHeader($filename)
     {
+        $filename = rawurlencode($filename);
         // loaderよりダウンロードするかどうか
-        if (!empty($this->request->getQuery('download')) && $this->request->getQuery('download') == true) {
-            $this->response->header('Content-Disposition', 'attachment;filename="' . rawurlencode($filename) . '"');
-
+        if (!empty($this->request->query['download']) && $this->request->query['download'] == true) {
             // IE/Edge対応
             if (strstr(env('HTTP_USER_AGENT'), 'MSIE') || strstr(env('HTTP_USER_AGENT'), 'Trident') || strstr(env('HTTP_USER_AGENT'), 'Edge')) {
                 $filename = mb_convert_encoding($filename, "SJIS", "UTF-8");
             }
-            $this->response->header('Content-Disposition', 'attachment;filename="' . $filename . '"');
         }
+        $this->response->header('Content-Disposition', 'attachment;filename="' . $filename . '"');
     }
 }


### PR DESCRIPTION
### PR作った理由
`loader のコピー.pdf` をダウンロードすると名前が `loader `になります