### PR TITLE
contentsFileHiddenのvalueを明示的に指定

### DIFF
--- a/src/View/Helper/ContentsFileHelper.php
+++ b/src/View/Helper/ContentsFileHelper.php
@@ -113,7 +113,7 @@ class ContentsFileHelper extends Helper {
         $hiddenInput = '';
         if (!empty($contentFileData)) {
             foreach ($contentFileData as $fieldParts => $v) {
-                $hiddenInput .= $this->Form->input($field . '.' . $fieldParts, ['type' => 'hidden']);
+                $hiddenInput .= $this->Form->input($field . '.' . $fieldParts, ['type' => 'hidden', 'value' => $v]);
             }
         }
         return $hiddenInput;


### PR DESCRIPTION
### 現象

- 登録済みのAttachmentsに対して更新を行う
- 新しいファイル名を設定
- validationエラーを起こす
    - 例)説明文を入れるような必須フォームをクリアするなど。Attachments以外でエラーを起こす
- エラー項目を修正してupdateする
- ファイル自体は更新されるが、Attachmentsのファイル名が更新されない。
    - validationエラーでhelperによるinput hiddenが作成されるがこのfile_nameのvalueが更新したいファイル名ではなく、変更前のファイル名になっている模様

### 対処

contentsFIleHelperのhidden項目作成時に、value値を明示的に指定する
