### PR TITLE
プラグイン名の追加

### DIFF
--- a/src/Controller/ContentsFileController.php
+++ b/src/Controller/ContentsFileController.php
@@ -77,7 +77,7 @@ class ContentsFileController extends AppController
                 $this->baseModel->{$checkMethodName}($this->request->getQuery('model_id'));
             }
             //attachementからデータを取得
-            $attachmentModel = TableRegistry::getTableLocator()->get('Attachments');
+            $attachmentModel = TableRegistry::getTableLocator()->get('ContentsFile.Attachments');
             $attachmentData = $attachmentModel->find('all')
                 ->where(['model' => $this->request->getQuery('model')])
                 ->where(['model_id' => $this->request->getQuery('model_id')])

--- a/src/Model/Behavior/Traits/NormalContentsFileBehaviorTrait.php
+++ b/src/Model/Behavior/Traits/NormalContentsFileBehaviorTrait.php
@@ -98,7 +98,7 @@ trait NormalContentsFileBehaviorTrait
     private function normalFileDelete(string $modelName, int $modelId, string $field): bool
     {
         //attachementからデータを取得
-        $attachmentModel = TableRegistry::getTableLocator()->get('Attachments');
+        $attachmentModel = TableRegistry::getTableLocator()->get('ContentsFile.Attachments');
         $attachmentData = $attachmentModel->find('all')
             ->where(['model' => $modelName])
             ->where(['model_id' => $modelId])

--- a/src/Model/Behavior/Traits/S3ContentsFileBehaviorTrait.php
+++ b/src/Model/Behavior/Traits/S3ContentsFileBehaviorTrait.php
@@ -109,7 +109,7 @@ trait S3ContentsFileBehaviorTrait
     private function s3FileDelete(string $modelName, int $modelId, string $field): bool
     {
         //attachementからデータを取得
-        $attachmentModel = TableRegistry::getTableLocator()->get('Attachments');
+        $attachmentModel = TableRegistry::getTableLocator()->get('ContentsFile.Attachments');
         $attachmentData = $attachmentModel->find('all')
             ->where(['model' => $modelName])
             ->where(['model_id' => $modelId])

--- a/src/Model/Entity/ContentsFileTrait.php
+++ b/src/Model/Entity/ContentsFileTrait.php
@@ -67,7 +67,7 @@ trait ContentsFileTrait
             //何もセットされていないとき
             if (empty($this->_fields[$property])) {
                 //attachmentからデータを探しに行く
-                $attachmentModel = TableRegistry::getTableLocator()->get('Attachments');
+                $attachmentModel = TableRegistry::getTableLocator()->get('ContentsFile.Attachments');
                 $attachmentData = $attachmentModel->find('all')
                     ->where(['model' => $this->getSource()])
                     ->where(['model_id' => $this->id])


### PR DESCRIPTION
アップデートによりモデルを定義する必要がでてきたので
`TableRegistry::getTableLocator()->get('Attachments');` -> 
`TableRegistry::getTableLocator()->get('ContentsFile.Attachments');` に変更

### 環境
CakePHP4.2

