### PR TITLE
minio用のconfigを追加

### DIFF
--- a/src/Aws/S3.php
+++ b/src/Aws/S3.php
@@ -50,6 +50,7 @@ class S3
         $endpoint = Configure::read('ContentsFile.Setting.S3.endpoint');
         if (!empty($endpoint)) {
             $config['endpoint'] = $endpoint;
+            $config['use_path_style_endpoint'] = true;
         }
         $sdk = new Sdk($config);
         $this->client = $sdk->createS3();


### PR DESCRIPTION
minio使用時のconfigに `'use_path_style_endpoint' => true` が必要なので追加

↓ 参照
https://docs.min.io/docs/how-to-use-aws-sdk-for-php-with-minio-server.html#:~:text=note%20that%20we%20set%20use_path_style_endpoint%20to%20true%20to%20use%20minio%20with%20aws%20sdk%20for%20php