### PR TITLE
名前空間をNetwork->Httpに変更

### DIFF
--- a/src/Aws/S3.php
+++ b/src/Aws/S3.php
@@ -4,8 +4,8 @@ namespace ContentsFile\Aws;
 
 use Aws\Sdk;
 use Cake\Core\Configure;
-use Cake\Network\Exception\InternalErrorException;
-use Cake\Network\Exception\NotFoundException;
+use Cake\Http\Exception\InternalErrorException;
+use Cake\Http\Exception\NotFoundException;
 
 /**
  * S3

--- a/src/Model/Behavior/ContentsFileBehavior.php
+++ b/src/Model/Behavior/ContentsFileBehavior.php
@@ -5,7 +5,7 @@ namespace ContentsFile\Model\Behavior;
 use ArrayObject;
 use Cake\Core\Configure;
 use Cake\Event\Event;
-use Cake\Network\Exception\InternalErrorException;
+use Cake\Http\Exception\InternalErrorException;
 use Cake\ORM\Behavior;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Table;

--- a/src/Model/Behavior/Traits/NormalContentsFileBehaviorTrait.php
+++ b/src/Model/Behavior/Traits/NormalContentsFileBehaviorTrait.php
@@ -3,7 +3,7 @@
 namespace ContentsFile\Model\Behavior\Traits;
 
 use Cake\Core\Configure;
-use Cake\Network\Exception\InternalErrorException;
+use Cake\Http\Exception\InternalErrorException;
 use Cake\ORM\TableRegistry;
 use Symfony\Component\Filesystem\Filesystem;
 

--- a/src/Model/Behavior/Traits/S3ContentsFileBehaviorTrait.php
+++ b/src/Model/Behavior/Traits/S3ContentsFileBehaviorTrait.php
@@ -4,7 +4,7 @@ namespace ContentsFile\Model\Behavior\Traits;
 
 use Cake\Core\Configure;
 use Cake\I18n\Time;
-use Cake\Network\Exception\InternalErrorException;
+use Cake\Http\Exception\InternalErrorException;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Security;
 use ContentsFile\Aws\S3;


### PR DESCRIPTION
Cake3.6 からNetwork -> Http に変更されているのでその対応です

すでにHttpに変更されている箇所もあったので合わせて変更しました
https://github.com/satthi/Contents-file/blob/master/src/Controller/ContentsFileController.php#L8

よろしくお願いします