### PR TITLE
PHP8.1のための対応調整

### DIFF
--- a/src/Controller/ContentsFileController.php
+++ b/src/Controller/ContentsFileController.php
@@ -24,19 +24,19 @@ class ContentsFileController extends AppController
     {
         parent::initialize();
         // /が最後についていない場合はつける
-        if (!preg_match('#/$#', Configure::read('ContentsFile.Setting.Normal.tmpDir'))) {
+        if (!preg_match('#/$#', Configure::read('ContentsFile.Setting.Normal.tmpDir') ?? '')) {
             Configure::write('ContentsFile.Setting.Normal.tmpDir', Configure::read('ContentsFile.Setting.Normal.tmpDir') . '/');
         }
-        if (!preg_match('#/$#', Configure::read('ContentsFile.Setting.Normal.fileDir'))) {
+        if (!preg_match('#/$#', Configure::read('ContentsFile.Setting.Normal.fileDir') ?? '')) {
             Configure::write('ContentsFile.Setting.Normal.fileDir', Configure::read('ContentsFile.Setting.Normal.fileDir') . '/');
         }
-        if (!preg_match('#/$#', Configure::read('ContentsFile.Setting.S3.tmpDir'))) {
+        if (!preg_match('#/$#', Configure::read('ContentsFile.Setting.S3.tmpDir') ?? '')) {
             Configure::write('ContentsFile.Setting.S3.tmpDir', Configure::read('ContentsFile.Setting.S3.tmpDir') . '/');
         }
-        if (!preg_match('#/$#', Configure::read('ContentsFile.Setting.S3.fileDir'))) {
+        if (!preg_match('#/$#', Configure::read('ContentsFile.Setting.S3.fileDir') ?? '')) {
             Configure::write('ContentsFile.Setting.S3.fileDir', Configure::read('ContentsFile.Setting.S3.fileDir') . '/');
         }
-        if (!preg_match('#/$#', Configure::read('ContentsFile.Setting.S3.workingDir'))) {
+        if (!preg_match('#/$#', Configure::read('ContentsFile.Setting.S3.workingDir') ?? '')) {
             Configure::write('ContentsFile.Setting.S3.workingDir', Configure::read('ContentsFile.Setting.S3.workingDir'). '/');
         }
     }


### PR DESCRIPTION
PHP8.1で動作させると以下のエラーが出るので修正をしています
```
PHP 8.1: Deprecated function: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated
```

よろしくお願いします。