### PR TITLE
CakePHP5.2対応における修正

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "source": "https://github.com/satthi/Contents-file"
     },
     "require": {
-        "cakephp/cakephp": "~5.0",
+        "cakephp/cakephp": "~5.2",
         "ext-gd": "*",
         "aws/aws-sdk-php": "3.*",
         "symfony/filesystem": "5.*",

--- a/src/Model/Behavior/ContentsFileBehavior.php
+++ b/src/Model/Behavior/ContentsFileBehavior.php
@@ -48,9 +48,9 @@ class ContentsFileBehavior extends Behavior
      * @param \Cake\Event\Event $event
      * @param \Cake\Datasource\EntityInterface $entity
      * @param \ArrayObject $options
-     * @return bool
+     * @return void
      */
-    public function afterSave(Event $event, EntityInterface $entity, ArrayObject $options): bool
+    public function afterSave(Event $event, EntityInterface $entity, ArrayObject $options): void
     {
         //設定値をentityから取得
         $contentsFileConfig = $entity->getContentsFileSettings();
@@ -60,7 +60,8 @@ class ContentsFileBehavior extends Behavior
             if ($entity->{'delete_' . $field} == true) {
                 // 該当フィールドを削除
                 if (!$this->fileDelete($entity, [$field])) {
-                    return false;
+                    $event->setResult(false);
+                    return;
                 }
                 // ファイルの削除に成功したら保存処理は飛ばす
                 continue;
@@ -95,7 +96,8 @@ class ContentsFileBehavior extends Behavior
 
                 // 通常とS3で画像保存方法の切り替え
                 if (!$this->{Configure::read('ContentsFile.Setting.type') . 'FileSave'}($fileInfo, $fieldSettings, $attachmentSaveData, $oldAttachmentData)) {
-                    return false;
+                    $event->setResult(false);
+                    return;
                 }
 
                 //元のデータがあれば更新にする
@@ -103,12 +105,13 @@ class ContentsFileBehavior extends Behavior
                     $attachmentEntity->id = $oldAttachmentData->id;
                 }
                 if (!$attachmentModel->save($attachmentEntity)) {
-                    return false;
+                    $event->setResult(false);
+                    return;
                 }
             }
         }
 
-        return true;
+        $event->setResult(true);
     }
 
     /**


### PR DESCRIPTION
# deprecatedが出ていたので対応
```
2025-09-03 15:33:47 debug: Since 5.2.0: Returning a value from event listeners is deprecated. Use `$event->setResult()` instead in `Model.afterSave` of `ContentsFile\Model\Behavior\ContentsFileBehavior::afterSave()`
/var/www/html/uninote/vendor/cakephp/cakephp/src/Event/EventManager.php, line: 316
You can disable all deprecation warnings by setting `Error.errorLevel` to `E_ALL & ~E_USER_DEPRECATED`. Adding `vendor/cakephp/cakephp/src/Event/EventManager.php` to `Error.ignoredDeprecationPaths` in your `config/app.php` config will mute deprecations from that file only. in /var/www/html/uninote/vendor/cakephp/cakephp/src/Core/functions.php on line 377
```